### PR TITLE
Fix: Add UE 5.6 Support

### DIFF
--- a/BuildPlugin.bat
+++ b/BuildPlugin.bat
@@ -11,7 +11,8 @@ mkdir %dst_dir%
 if not "%1" == "" goto engine_provided
 
 ::call :build %uplugin_file% 5.3
-call :build %uplugin_file% 5.4
+::call :build %uplugin_file% 5.4
+call :build %uplugin_file% 5.6
 
 goto :eof
 

--- a/BuildPlugin.bat
+++ b/BuildPlugin.bat
@@ -12,6 +12,7 @@ if not "%1" == "" goto engine_provided
 
 ::call :build %uplugin_file% 5.3
 ::call :build %uplugin_file% 5.4
+::call :build %uplugin_file% 5.5
 call :build %uplugin_file% 5.6
 
 goto :eof

--- a/Plugins/LookingGlass/Source/LookingGlassRuntime/Private/Game/LookingGlassSceneCaptureComponent2D.cpp
+++ b/Plugins/LookingGlass/Source/LookingGlassRuntime/Private/Game/LookingGlassSceneCaptureComponent2D.cpp
@@ -1,4 +1,5 @@
 #include "Game/LookingGlassSceneCaptureComponent2D.h"
+#include "Runtime/Launch/Resources/Version.h" // ensure proper version defines
 #include "Game/LookingGlassDrawFrustumComponent.h"
 #include "LookingGlassBridge.h"
 #include "LookingGlassSettings.h"
@@ -233,6 +234,7 @@ void ULookingGlassSceneCaptureComponent2D::EndPlay(const EEndPlayReason::Type En
 	ILookingGlassRuntime::Get().GameLookingGlassCaptureComponents.Remove(this);
 }
 
+#if (ENGINE_MAJOR_VERSION < 5) || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 6)
 void ULookingGlassSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* Scene)
 {
 	// This function is called by USceneCaptureComponent2D::CaptureSceneDeferred() and UpdateDeferredCaptures()
@@ -245,6 +247,21 @@ void ULookingGlassSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInte
 		Super::UpdateSceneCaptureContents(Scene);
 	}
 }
+#else // EU5.6+
+// UE 5.6 Needs ISceneRenderBuilder argument signature
+void ULookingGlassSceneCaptureComponent2D::UpdateSceneCaptureContents(FSceneInterface* Scene, class ISceneRenderBuilder& SceneRenderBuilder)
+{
+	// This function is called by USceneCaptureComponent2D::CaptureSceneDeferred() and UpdateDeferredCaptures()
+	// when any property of this component is changed. This capture is useless because it is executed in a
+	// different way, also it causes engine to crash with NULL render target. So, let's just declare an empty
+	// implementation. The crash was caused by PostEditChangeProperty or OnRegister calls to parent class.
+
+	if (bAllow2DCapture)
+	{
+		Super::UpdateSceneCaptureContents(Scene, SceneRenderBuilder);
+	}
+}
+#endif
 
 /**
  * This is called when property is modified by InterpPropertyTracks

--- a/Plugins/LookingGlass/Source/LookingGlassRuntime/Private/Render/LookingGlassViewportClient.cpp
+++ b/Plugins/LookingGlass/Source/LookingGlassRuntime/Private/Render/LookingGlassViewportClient.cpp
@@ -706,7 +706,7 @@ bool FLookingGlassViewportClient::InputMotion(FViewport * InViewport, int32 Cont
 {
 	return false;
 }
-#else //(ENGINE_MAJOR_VERSION > 5 && ENGINE_MINOR_VERSION >= 6)
+#else // EU5.6+
 
 // UE 5.6 has function signature change mainly
 //		- use of FInputKeyEventArgs EventArgs

--- a/Plugins/LookingGlass/Source/LookingGlassRuntime/Private/Render/LookingGlassViewportClient.cpp
+++ b/Plugins/LookingGlass/Source/LookingGlassRuntime/Private/Render/LookingGlassViewportClient.cpp
@@ -1,4 +1,5 @@
 #include "Render/LookingGlassViewportClient.h"
+#include "Runtime/Launch/Resources/Version.h" // ensure proper version defines
 
 #include "Render/LookingGlassRendering.h"
 #include "Game/LookingGlassCapture.h"
@@ -13,8 +14,6 @@
 
 #include "CanvasItem.h"
 #include "ImageUtils.h"
-
-#include "Runtime/Launch/Resources/Version.h"
 
 #include "Misc/FileHelper.h"
 #include "GameFramework/PlayerController.h"
@@ -521,6 +520,7 @@ void FLookingGlassViewportClient::RenderToQuilt(ULookingGlassSceneCaptureCompone
 	}
 }
 
+#if (ENGINE_MAJOR_VERSION < 5) || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 6)
 bool FLookingGlassViewportClient::InputKey(FViewport * InViewport, int32 ControllerId, FKey Key, EInputEvent EventType, float AmountDepressed, bool bGamepad)
 {
 	ILookingGlassRuntime::Get().OnLookingGlassInputKeyDelegate().Broadcast(InViewport, ControllerId, Key, EventType, AmountDepressed, bGamepad);
@@ -706,6 +706,162 @@ bool FLookingGlassViewportClient::InputMotion(FViewport * InViewport, int32 Cont
 {
 	return false;
 }
+#else //(ENGINE_MAJOR_VERSION > 5 && ENGINE_MINOR_VERSION >= 6)
+
+// UE 5.6 has function signature change mainly
+//		- use of FInputKeyEventArgs EventArgs
+//		- replacement of FDateTime DeviceTimestamp to uint64 Timestamp and int32
+//		- replacement of int32 ControllerId to FInputDeviceId ControllerId
+
+bool FLookingGlassViewportClient::InputKey(const FInputKeyEventArgs& EventArgs)
+{
+	ILookingGlassRuntime::Get().OnLookingGlassInputKeyDelegate().Broadcast(EventArgs.Viewport, EventArgs.ControllerId, EventArgs.Key, EventArgs.Event, EventArgs.AmountDepressed, EventArgs.IsGamepad());
+
+	auto LookingGlassSettings = GetDefault<ULookingGlassSettings>();
+
+	// Process special input first
+	if (EventArgs.Key == EKeys::Escape && EventArgs.Event == EInputEvent::IE_Pressed)
+	{
+		ILookingGlassRuntime::Get().StopPlayer();
+	}
+
+	if (LookingGlassSettings->LookingGlassScreenshotQuiltSettings.InputKey == EventArgs.Key && EventArgs.Event == EInputEvent::IE_Pressed)
+	{
+		PrepareScreenshotQuilt(LookingGlassSettings->LookingGlassScreenshotQuiltSettings.FileName, true);
+	}
+
+	if (LookingGlassSettings->LookingGlassScreenshot2DSettings.InputKey == EventArgs.Key && EventArgs.Event == EInputEvent::IE_Pressed)
+	{
+		PrepareScreenshot2D(LookingGlassSettings->LookingGlassScreenshot2DSettings.FileName, true);
+	}
+
+	if (IgnoreInput())
+	{
+		return false;
+	}
+
+	bool bResult = false;
+
+	// Make sure we are playing in separate window
+	if (ILookingGlassRuntime::Get().GetCurrentLookingGlassModeType() == ELookingGlassModeType::PlayMode_InSeparateWindow)
+	{
+		// Make sure we are in game play mode
+		if (GEngine->GameViewport != nullptr)
+		{
+			ULocalPlayer* FirstLocalPlayerFromController = GEngine->GameViewport->GetWorld()->GetFirstLocalPlayerFromController();
+
+			UE_LOG(LookingGlassLogInput, Verbose, TEXT(">> InputKey %s, FirstLocalPlayerFromController %p, ControllerId %d"), *EventArgs.Key.ToString(), FirstLocalPlayerFromController, EventArgs.ControllerId);
+
+			if (FirstLocalPlayerFromController && FirstLocalPlayerFromController->PlayerController)
+			{
+				bResult = FirstLocalPlayerFromController->PlayerController->InputKey(EventArgs);
+			}
+
+			// A gameviewport is always considered to have responded to a mouse buttons to avoid throttling
+			if (!bResult && EventArgs.Key.IsMouseButton())
+			{
+				bResult = true;
+			}
+		}
+	}
+
+	return bResult;
+}
+
+bool FLookingGlassViewportClient::InputAxis(const FInputKeyEventArgs& EventArgs)
+{
+	if (IgnoreInput())
+	{
+		return false;
+	}
+
+	if (GWorld == nullptr || GEngine == nullptr || GEngine->GameViewport == nullptr || &GEngine->GameViewport->Viewport == nullptr)
+	{
+		return false;
+	}
+
+	bool bResult = false;
+
+	// Don't allow mouse/joystick input axes while in PIE and the console has forced the cursor to be visible.  It's
+	// just distracting when moving the mouse causes mouse look while you are trying to move the cursor over a button
+	// in the editor!
+	if (!(GEngine->GameViewport->Viewport->IsSlateViewport() && GEngine->GameViewport->Viewport->IsPlayInEditorViewport()) || GEngine->GameViewport->ViewportConsole == NULL || !GEngine->GameViewport->ViewportConsole->ConsoleActive())
+	{
+		// route to subsystems that care
+		if (GEngine->GameViewport->ViewportConsole != NULL)
+		{
+			bResult = GEngine->GameViewport->ViewportConsole->InputAxis(EventArgs.InputDevice, EventArgs.Key, EventArgs.AmountDepressed, EventArgs.DeltaTime, EventArgs.NumSamples, EventArgs.IsGamepad());
+		}
+		if (!bResult)
+		{
+			ULocalPlayer* const TargetPlayer = GEngine->GetLocalPlayerFromControllerId(GEngine->GameViewport, EventArgs.ControllerId);
+			if (TargetPlayer && TargetPlayer->PlayerController)
+			{
+				bResult = TargetPlayer->PlayerController->InputKey(EventArgs);
+			}
+		}
+
+		// For PIE, let the next PIE window handle the input if none of our players did
+		// (this allows people to use multiple controllers to control each window)
+		if (EventArgs.Viewport->IsPlayInEditorViewport())
+		{
+			UGameViewportClient *NextViewport = GEngine->GetNextPIEViewport(GEngine->GameViewport);
+			if (NextViewport)
+			{
+				bResult = NextViewport->InputAxis(EventArgs);
+			}
+		}
+
+		if (EventArgs.Viewport->IsSlateViewport() && EventArgs.Viewport->IsPlayInEditorViewport())
+		{
+			// Absorb all keys so game input events are not routed to the Slate editor frame
+			bResult = true;
+		}
+	}
+
+	return bResult;
+}
+
+bool FLookingGlassViewportClient::InputChar(FViewport * InViewport, int32 ControllerId, TCHAR Character)
+{
+	return false;
+}
+
+bool FLookingGlassViewportClient::InputTouch(FViewport* InViewport, const FInputDeviceId DeviceId, uint32 Handle, ETouchType::Type Type, const FVector2D& TouchLocation, float Force, uint32 TouchpadIndex, const uint64 Timestamp)
+{
+	if (IgnoreInput())
+	{
+		return false;
+	}
+
+	if (GWorld == nullptr || GEngine == nullptr || GEngine->GameViewport == nullptr || &GEngine->GameViewport->Viewport == nullptr)
+	{
+		return false;
+	}
+
+	// route to subsystems that care
+	bool bResult = false;
+	if (GEngine->GameViewport->ViewportConsole)
+	{
+		bResult = GEngine->GameViewport->ViewportConsole->InputTouch(DeviceId, Handle, Type, TouchLocation, Force, TouchpadIndex, Timestamp);
+	}
+	if (!bResult)
+	{
+		ULocalPlayer* const TargetPlayer = GEngine->GetLocalPlayerFromControllerId(GEngine->GameViewport, DeviceId.GetId());
+		if (TargetPlayer && TargetPlayer->PlayerController)
+		{
+			bResult = TargetPlayer->PlayerController->InputTouch(DeviceId, Handle, Type, TouchLocation, Force, TouchpadIndex, Timestamp);
+		}
+	}
+
+	return bResult;
+}
+
+bool FLookingGlassViewportClient::InputMotion(FViewport* InViewport, const FInputDeviceId DeviceId, const FVector& Tilt, const FVector& RotationRate, const FVector& Gravity, const FVector& Acceleration, const uint64 Timestamp)
+{
+	return false;
+}
+#endif // EU5.6+
 
 void FLookingGlassViewportClient::RedrawRequested(FViewport * InViewport)
 {

--- a/Plugins/LookingGlass/Source/LookingGlassRuntime/Public/Game/LookingGlassSceneCaptureComponent2D.h
+++ b/Plugins/LookingGlass/Source/LookingGlassRuntime/Public/Game/LookingGlassSceneCaptureComponent2D.h
@@ -1,6 +1,7 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
+#include "Runtime/Launch/Resources/Version.h" // ensure proper version defines
 
 #include "CoreMinimal.h"
 #include "Components/SceneCaptureComponent2D.h"
@@ -62,7 +63,13 @@ public:
 	static void CalculateViewRect(float& U, float& V, float& SizeU, float& SizeV, int32 ViewRows, int32 ViewColumns, int32 ViewCount, int32 ViewIndex);
 
 private:
+
+#if (ENGINE_MAJOR_VERSION < 5) || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 6)
 	UTextureRenderTarget2D* RenderTarget;
+#else // EU5.6+
+	// Fix warning AddReferenceObject
+	TObjectPtr<UTextureRenderTarget2D> RenderTarget;
+#endif
 
 	// Same as ViewInfoArr.Num(). Number of views is limited either by GMaxTextureDimensions or MaxViews.
 	uint32 NumViews;
@@ -160,7 +167,12 @@ public:
 	//~ End UActorComponent Interface
 
 	//~ Begin USceneCaptureComponent Interface
+#if (ENGINE_MAJOR_VERSION < 5) || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 6)
 	virtual void UpdateSceneCaptureContents(FSceneInterface* Scene) override;
+#else // EU5.6+
+	// UE 5.6 Needs ISceneRenderBuilder argument signature
+	virtual void UpdateSceneCaptureContents(FSceneInterface* Scene, class ISceneRenderBuilder& SceneRenderBuilder) override;
+#endif
 	//~ End USceneCaptureComponent Interface
 
 	/** Top-level rendering function for making a hologram picture */

--- a/Plugins/LookingGlass/Source/LookingGlassRuntime/Public/Render/LookingGlassViewportClient.h
+++ b/Plugins/LookingGlass/Source/LookingGlassRuntime/Public/Render/LookingGlassViewportClient.h
@@ -162,7 +162,7 @@ public:
 	virtual bool InputChar(FViewport* Viewport, int32 ControllerId, TCHAR Character) override;
 	virtual bool InputTouch(FViewport* Viewport, int32 ControllerId, uint32 Handle, ETouchType::Type Type, const FVector2D& TouchLocation, float Force, FDateTime DeviceTimestamp, uint32 TouchpadIndex) override;
 	virtual bool InputMotion(FViewport* Viewport, int32 ControllerId, const FVector& Tilt, const FVector& RotationRate, const FVector& Gravity, const FVector& Acceleration) override;
-#else //(ENGINE_MAJOR_VERSION > 5 && ENGINE_MINOR_VERSION >= 6)
+#else // EU5.6+
 
 	// UE 5.6 has function signature change mainly
 	//		- use of FInputKeyEventArgs EventArgs

--- a/Plugins/LookingGlass/Source/LookingGlassRuntime/Public/Render/LookingGlassViewportClient.h
+++ b/Plugins/LookingGlass/Source/LookingGlassRuntime/Public/Render/LookingGlassViewportClient.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Runtime/Launch/Resources/Version.h" // ensure proper version defines
 
 #include "CoreMinimal.h"
 #include "Misc/CoreMisc.h"
@@ -116,7 +117,9 @@ public:
 	 */
 
 	virtual void Draw(FViewport* Viewport, FCanvas* Canvas) override;
+	
 
+#if (ENGINE_MAJOR_VERSION < 5) || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 6)
 	/**
 	 * @fn	virtual bool FLookingGlassViewportClient::InputKey(FViewport* Viewport, int32 ControllerId, FKey Key, EInputEvent Event, float AmountDepressed = 1.0f, bool bGamepad = false) override;
 	 *
@@ -155,10 +158,48 @@ public:
 
 	//todo: should override a different method since UE5.1
 	virtual bool InputAxis(FViewport* Viewport, int32 ControllerId, FKey Key, float Delta, float DeltaTime, int32 NumSamples = 1, bool bGamepad = false) override;
-
+	
 	virtual bool InputChar(FViewport* Viewport, int32 ControllerId, TCHAR Character) override;
 	virtual bool InputTouch(FViewport* Viewport, int32 ControllerId, uint32 Handle, ETouchType::Type Type, const FVector2D& TouchLocation, float Force, FDateTime DeviceTimestamp, uint32 TouchpadIndex) override;
 	virtual bool InputMotion(FViewport* Viewport, int32 ControllerId, const FVector& Tilt, const FVector& RotationRate, const FVector& Gravity, const FVector& Acceleration) override;
+#else //(ENGINE_MAJOR_VERSION > 5 && ENGINE_MINOR_VERSION >= 6)
+
+	// UE 5.6 has function signature change mainly
+	//		- use of FInputKeyEventArgs EventArgs
+	//		- replacement of FDateTime DeviceTimestamp to uint64 Timestamp and int32
+	//		- replacement of int32 ControllerId to FInputDeviceId ControllerId
+
+	/**
+	 * @fn	virtual bool FLookingGlassViewportClient::InputKey(const FInputKeyEventArgs& EventArgs) override;
+	 *
+	 * @brief	Check a key event received by the viewport. If the viewport client uses the event, it
+	 * 			should return true to consume it.
+	 *
+	 * @param [in]	EventArgs			- The input event arguments for this axis movement.
+	 *
+	 * @returns	True to consume the axis movement, false to pass it on.
+	 */
+
+	virtual bool InputKey(const FInputKeyEventArgs& EventArgs) override;
+
+	/**
+	 * @fn	virtual bool FLookingGlassViewportClient::InputAxis(const FInputKeyEventArgs& EventArgs) override;
+	 *
+	 * @brief	Check an axis movement received by the viewport. If the viewport client uses the
+	 * 			movement, it should return true to consume it.
+	 *
+	 * @param [in]	EventArgs			- The input event arguments for this axis movement.
+	 *
+	 * @returns	True to consume the axis movement, false to pass it on.
+	 */
+
+	virtual bool InputAxis(const FInputKeyEventArgs& EventArgs) override;
+	
+	virtual bool InputChar(FViewport* Viewport, int32 ControllerId, TCHAR Character) override;
+	virtual bool InputTouch(FViewport* Viewport, const FInputDeviceId DeviceId, uint32 Handle, ETouchType::Type Type, const FVector2D& TouchLocation, float Force, uint32 TouchpadIndex, const uint64 Timestamp) override;
+	virtual bool InputMotion(FViewport* Viewport, const FInputDeviceId DeviceId, const FVector& Tilt, const FVector& RotationRate, const FVector& Gravity, const FVector& Acceleration, const uint64 Timestamp) override;
+#endif // EU5.6+
+	
 
 	/**
 	 * @fn	virtual UWorld* FLookingGlassViewportClient::GetWorld() const override

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Alternatively you may get the snapshot of the repository using downloading of zi
 - Pre-requisites: 
 - Looking Glass Bridge 2.5.1 or higher
 - Visual Studio 2022
-- **Unreal Engine 5.5 requires MSVC v143 (14.38 - 17.8). Working with Unreal Engine with another MSVC version will cause the engine to fail to compile.**
+- **Unreal Engine 5.6 requires MSVC v143 (14.38 - 17.8). Working with Unreal Engine with another MSVC version will cause the engine to fail to compile.**
 - Download the project from Github (see above).
 - Find the UnrealSDK.uproject file in the root folder of repository.
 - If you have multiple Unreal engine versions installed, right click on this file, select "Switch unreal engine version" option and select the one which you want to use with this plugin.

--- a/UnrealSDK.uproject
+++ b/UnrealSDK.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "5.5",
+	"EngineAssociation": "5.6",
 	"Category": "",
 	"Description": "",
 	"Modules": [


### PR DESCRIPTION
This PR adds compatibility for Unreal Engine 5.6.

### Changes
- Use `#if-#else-#endif` blocks to preserve backward compatibility:
  - `#if (ENGINE_MAJOR_VERSION < 5) || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 6)`
- Refactor deprecated functions and signatures in :
  - `LookingGlassViewportClient.h/cpp`
  - `LookingGlassSceneCaptureComponent2D.h/cpp`
- Move `Version.h` earlier in source files to avoid compile-time issues:
   - `#include "Runtime/Launch/Resources/Version.h"`
- Fix warning from `AddReferencedObjects`:
  - Wrap `RenderTarget` in `TObjectPtr<UTextureRenderTarget2D>`
- Update:
  - `README.md`
  - `BuildPlugin.bat`
  - `<project-files>` with UE 5.6 references
- Tested builds:
  - `C++ UE-5.6 <project>` - success
  - `UnrealSDK.uproject` - success
  - `BuildPlugin.bat` - appears successful
---
Let me know if you'd prefer this to target a different branch, or if you have any questions.